### PR TITLE
Fix formatting (insert line breaks in index)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,15 +7,27 @@ To discuss the contents of this document, or hang out with likely minded people 
 You can find a one page version of this site here : [One page version](one.md)
 
 [Documentations](documentation.md)
+
 [Emulators](emulators.md)
+
 [Exploits & softmods](exploits_softmods.md)
+
 [Game ports](game_ports.md)
+
 [Hardware mods & adapters](hardware_mod_adapters.md)
+
 [Misc., tools & others](misc_tools_other.md)
+
 [Nugget stuff](nugget.md)
+
 [Others sites](other.md)
+
 [Programming ressources](programming_ressources.md)
+
 [Retail source code](retail_source_code.md)
+
 [Reverse_engineering](reverse_engineering.md)
+
 [SDKs, toolchains & libraries](sdk_toolchains_libraries.md)
+
 [Source code examples](source_code_examples.md)


### PR DESCRIPTION
Seems like my last commit broke the index page, sorry (it had trailing whitespace which inserted line breaks, but it's better to do it manually)